### PR TITLE
echoing command before execution, preventing failure on empty outputs

### DIFF
--- a/index.py
+++ b/index.py
@@ -24,15 +24,16 @@ def lambda_handler(event, context):
     if (command_request_type in properties and
         properties[command_request_type] != ""):
         try:
+            print(properties[command_request_type])
             output = run_cmd("/var/task/wrapper " + properties[command_request_type])
-            if output is None:
+            if output is None or output == "":
                 print("Null return")
                 r = null_return
             else:
+                print(output)
                 r = json.loads(output)
             sendResponseCfn(event, context, "SUCCESS", r, "Command Executed.")
             print("Command executed.")
-            print("Response: " + json.dumps(r))
         except Exception as e:
             print(e)
             sendResponseCfn(event, context, "FAILED", null_return, "Failed to execute the command.")


### PR DESCRIPTION
echoing command before execution, preventing failure on empty outputs (e.g. s3api put-bucket-notification-configuration)